### PR TITLE
Resolve ruby 2.5 BigDecimal deprecation warning

### DIFF
--- a/lib/graphene/axis.rb
+++ b/lib/graphene/axis.rb
@@ -3,16 +3,16 @@ module Graphene
     include Renderable
 
     attr_accessor :min, :max, :line_thickness, :line_colour
-    
+
     # number of ticks
     attr_accessor :ticks
-    
+
     # spacing of ticks - would normally only need to set this OR \ticks
     attr_accessor :tick_spacing
-    
+
     # position (in axis value units) of the first tick
     attr_accessor :tick_offset
-    
+
     attr_accessor :tick_colour, :tick_opacity, :tick_thickness, :tick_length, :tick_position, :tick_values
     attr_writer :label, :value_labels, :grid_ticks
     attr_reader :chart, :type
@@ -93,7 +93,7 @@ module Graphene
       # as dates have a non-discrete type (rational, in the case of dates) as the different type, and
       # so don't need such a workaround.
       calculated_range = calculated_max - calculated_min
-      calculated_range = BigDecimal.new(calculated_range.to_s) if calculated_range.is_a?(Integer)
+      calculated_range = BigDecimal(calculated_range.to_s) if calculated_range.is_a?(Integer)
       calculated_range/(ticks - 1) if ticks && ticks > 1
     end
 

--- a/lib/graphene/grid.rb
+++ b/lib/graphene/grid.rb
@@ -38,14 +38,14 @@ module Graphene
 
       [[:x, x_ticks], [:y, y_ticks]].select {|a,b| b && b > 0}.each do |axis, ticks|
         if (axis == :x) == @point_mapper.horizontal?
-          dy = height / BigDecimal.new((ticks - 1).to_s)
+          dy = height / BigDecimal((ticks - 1).to_s)
           ticks.floor.times do |cy|
             y = top + height - cy * dy # need to go + height - offset because drawing y coordinates go down but graph coords go up, and we might not have an exact number of ticks in the height
             instructions << [:move, left, y]
             instructions << [:lineto, left + width, y]
           end
         else
-          dx = width / BigDecimal.new((ticks - 1).to_s)
+          dx = width / BigDecimal((ticks - 1).to_s)
           ticks.floor.times do |cx|
             x = left + cx * dx
             instructions << [:move, x, top]


### PR DESCRIPTION
Resolved 3 instances of `warning: BigDecimal.new is deprecated; use BigDecimal() method instead.`